### PR TITLE
New/logout

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ pymongo = "*"
 mongoengine = "*"
 flask-jwt-extended = "*"
 flask-bcrypt = "*"
+redis = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "80c5fa21b09f683c235a998c2ab0b41dcb734da2568ec921be6b49de5724d2b0"
+            "sha256": "96bb189b8a5583442d8e0e6d751f98cf1851ea95edc88e2e0271bd13106759ef"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -200,11 +200,11 @@
         },
         "mongoengine": {
             "hashes": [
-                "sha256:6fe9ac408a5aa84d06fa2a33106f6ac9916e36f899c14271d9b38b5b6729008f",
-                "sha256:930639c49de876ba56643a007f9ac5b864ebda031fb8dffaded9e4e44f774f9f"
+                "sha256:424edf66a5fadd5e22295b9c1b1604d96e7bd14273a0cbe281b5ddac2edb97e3",
+                "sha256:ca4993f39df07dabbf7503d56c4eba67dbdac5d2ec83ccffe20d38d5d02c2d3b"
             ],
             "index": "pypi",
-            "version": "==0.16.2"
+            "version": "==0.16.3"
         },
         "pycparser": {
             "hashes": [
@@ -214,10 +214,10 @@
         },
         "pyjwt": {
             "hashes": [
-                "sha256:30b1380ff43b55441283cc2b2676b755cca45693ae3097325dea01f3d110628c",
-                "sha256:4ee413b357d53fd3fb44704577afac88e72e878716116270d722723d65b42176"
+                "sha256:00414bfef802aaecd8cc0d5258b6cb87bd8f553c2986c2c5f29b19dd5633aeb7",
+                "sha256:ddec8409c57e9d371c6006e388f91daf3b0b43bdf9fcbf99451fb7cf5ce0a86d"
             ],
-            "version": "==1.6.4"
+            "version": "==1.7.0"
         },
         "pymongo": {
             "hashes": [
@@ -265,6 +265,14 @@
                 "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
             ],
             "version": "==2018.7"
+        },
+        "redis": {
+            "hashes": [
+                "sha256:2100750629beff143b6a200a2ea8e719fcf26420adabb81402895e144c5083cf",
+                "sha256:8e0bdd2de02e829b6225b25646f9fb9daffea99a252610d040409a6738541f0a"
+            ],
+            "index": "pypi",
+            "version": "==3.0.1"
         },
         "six": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ Since Minstrel is free and open-source, everybody is welcome to fork, reuse and 
 - Python
 - Pipenv
 - MongoDB
+- Redis
 
 First make sure python is working on your system, check with
 ```
 python3 -v
 ```
-Configure MongoDB and run it
+Configure MongoDB and Redis and then run them
 
 After cloning the repo, simply run:
 ```


### PR DESCRIPTION
Users should be able to log out. To this end, a Redis database is used to store the status (is_revoked?) of JWTs. Redis is used instead of the already present MongoDB, because Redis is a lot faster and efficient for such small key-value records. Two routes exist, one to revoke access token, the other for refresh tokens.